### PR TITLE
Correction Unitnames plants

### DIFF
--- a/DispaSET/preprocessing/data_handler.py
+++ b/DispaSET/preprocessing/data_handler.py
@@ -199,7 +199,7 @@ def merge_series(plants, data, mapping, method='WeightedAverage', tablename=''):
 
     plants.index = range(len(plants))
     merged = pd.DataFrame(index=data.index)
-    unitnames = [plants['Unit'][x] for x in mapping['NewIndex']]
+    unitnames = plants.Unit.values.tolist()
     # First check the data:
     if not isinstance(data,pd.DataFrame):
         logging.error('The input "' + tablename + '" to the merge_series function must be a dataframe')


### PR DESCRIPTION
The unit names should be the original unit names and not the merged unit names. After LP Clustering this error is always produced.

![lp_bug](https://user-images.githubusercontent.com/25181032/43687895-66dedd76-98de-11e8-902b-840465e6499a.PNG)
