### PR TITLE
Remove pandas.datetime

### DIFF
--- a/dispaset/postprocessing/data_handler.py
+++ b/dispaset/postprocessing/data_handler.py
@@ -123,9 +123,9 @@ def get_sim_results(path='.', cache=None, temp_path=None, return_xarray=False, r
     # Set datetime index:
     StartDate = inputs['config']['StartDate']
     StopDate = inputs['config']['StopDate']  # last day of the simulation with look-ahead period
-    StopDate_long = pd.datetime(*StopDate) + dt.timedelta(days=inputs['config']['LookAhead'])
-    index = pd.date_range(start=pd.datetime(*StartDate), end=pd.datetime(*StopDate), freq='h')
-    index_long = pd.date_range(start=pd.datetime(*StartDate), end=StopDate_long, freq='h')
+    StopDate_long = dt.datetime(*StopDate) + dt.timedelta(days=inputs['config']['LookAhead'])
+    index = pd.date_range(start=dt.datetime(*StartDate), end=dt.datetime(*StopDate), freq='h')
+    index_long = pd.date_range(start=dt.datetime(*StartDate), end=StopDate_long, freq='h')
 
     keys = ['LostLoad_2U', 'LostLoad_3U', 'LostLoad_MaxPower', 'LostLoad_MinPower', 'LostLoad_RampUp',
             'LostLoad_RampDown', 'LostLoad_2D','ShadowPrice', 'StorageShadowPrice'] #'status'
@@ -280,8 +280,8 @@ def ds_to_df(inputs):
     # config = parameters['Config']['val']
     try:
         config = inputs['config']
-        first_day = pd.datetime(config['StartDate'][0], config['StartDate'][1], config['StartDate'][2], 0)
-        last_day = pd.datetime(config['StopDate'][0], config['StopDate'][1], config['StopDate'][2], 23)
+        first_day = dt.datetime(config['StartDate'][0], config['StartDate'][1], config['StartDate'][2], 0)
+        last_day = dt.datetime(config['StopDate'][0], config['StopDate'][1], config['StopDate'][2], 23)
         dates = pd.date_range(start=first_day, end=last_day, freq='1h')
         timeindex = True
     except KeyError:

--- a/dispaset/postprocessing/postprocessing.py
+++ b/dispaset/postprocessing/postprocessing.py
@@ -7,6 +7,7 @@ Set of functions useful to analyse to DispaSET output data.
 
 from __future__ import division
 
+import datetime as dt
 import logging
 import sys
 
@@ -205,7 +206,7 @@ def get_result_analysis(inputs, results):
 
     StartDate = inputs['config']['StartDate']
     StopDate = inputs['config']['StopDate']
-    index = pd.date_range(start=pd.datetime(*StartDate), end=pd.datetime(*StopDate), freq='h')
+    index = pd.date_range(start=dt.datetime(*StartDate), end=dt.datetime(*StopDate), freq='h')
 
     # Aggregated values:
     demand = {}

--- a/dispaset/preprocessing/data_handler.py
+++ b/dispaset/preprocessing/data_handler.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import logging
 import os
 import sys
@@ -327,8 +328,8 @@ def load_time_series(config,path,header='infer'):
         elif len(data) == 8760:
             logging.info('A numerical index has been found for file ' + path + 
                          '. Since it contains 8760 elements, it is assumed that it corresponds to a whole year')
-            data.index = pd.DatetimeIndex(start=pd.datetime(*(config['idx'][0].year,1,1,0,0)),
-                                                        end=pd.datetime(*(config['idx'][0].year,12,31,23,59,59)),
+            data.index = pd.DatetimeIndex(start=dt.datetime(*(config['idx'][0].year,1,1,0,0)),
+                                                        end=dt.datetime(*(config['idx'][0].year,12,31,23,59,59)),
                                                         freq=commons['TimeStep'])
         else:
             logging.critical('A numerical index has been found for file ' + path + 

--- a/dispaset/preprocessing/preprocessing.py
+++ b/dispaset/preprocessing/preprocessing.py
@@ -65,14 +65,14 @@ def build_simulation(config, profiles=None):
     config['StopDate'] = (y_end, m_end, d_end, 23, 59, 00)  # updating stopdate to the end of the day
     
     # Indexes of the simulation:
-    config['idx'] = pd.DatetimeIndex(pd.date_range(start=pd.datetime(*config['StartDate']),
-                                             end=pd.datetime(*config['StopDate']),
+    config['idx'] = pd.DatetimeIndex(pd.date_range(start=dt.datetime(*config['StartDate']),
+                                             end=dt.datetime(*config['StopDate']),
                                              freq=commons['TimeStep'])).tz_localize(None)
 
 
     # Indexes for the whole year considered in StartDate
-    idx_year = pd.DatetimeIndex(pd.date_range(start=pd.datetime(*(config['StartDate'][0],1,1,0,0)),
-                                                        end=pd.datetime(*(config['StartDate'][0],12,31,23,59,59)),
+    idx_year = pd.DatetimeIndex(pd.date_range(start=dt.datetime(*(config['StartDate'][0],1,1,0,0)),
+                                                        end=dt.datetime(*(config['StartDate'][0],12,31,23,59,59)),
                                                         freq=commons['TimeStep'])
                                           )
     
@@ -943,8 +943,8 @@ def mid_term_scheduling(config, zones, profiles=None):
     config['StopDate'] = (y_end, m_end, d_end, 23, 59, 00)  # updating stopdate to the end of the day
     
     # Indexes of the simualtion:
-    idx_std = pd.DatetimeIndex(start=pd.datetime(*config['StartDate']), 
-                               end=pd.datetime(*config['StopDate']),
+    idx_std = pd.DatetimeIndex(start=dt.datetime(*config['StartDate']), 
+                               end=dt.datetime(*config['StopDate']),
                                freq=commons['TimeStep'])
     idx_utc_noloc = idx_std - dt.timedelta(hours=1)
     idx = idx_utc_noloc

--- a/dispaset/pyomo/model.py
+++ b/dispaset/pyomo/model.py
@@ -14,6 +14,7 @@ Functions:
 #######################################################################################################################
 
 
+import datetime as dt
 import sys
 import os
 import logging
@@ -691,8 +692,8 @@ def DispaSolve(sets, parameters, LPFormulation=False, path_cplex = ''):
     Nhours = len(sets['h'])
 
     # Build pandas indexes based on the config variables:
-    first = pd.datetime(config['FirstDay', 'year'], config['FirstDay', 'month'], config['FirstDay', 'day'], 0, 0, 0)
-    last = pd.datetime(config['LastDay', 'year'], config['LastDay', 'month'], config['LastDay', 'day'], 23, 59, 59)
+    first = dt.datetime(config['FirstDay', 'year'], config['FirstDay', 'month'], config['FirstDay', 'day'], 0, 0, 0)
+    last = dt.datetime(config['LastDay', 'year'], config['LastDay', 'month'], config['LastDay', 'day'], 23, 59, 59)
 
     # Index corresponding to the data:
     index_all = pd.DatetimeIndex(start=first, end=last, freq='h')


### PR DESCRIPTION
The pandas.datetime class is now deprecated.
Import from datetime instead (GH30610).

https://github.com/pandas-dev/pandas/issues/30610