### PR TITLE
Fix PyYAML deprecation

### DIFF
--- a/Docs/workflow.rst
+++ b/Docs/workflow.rst
@@ -17,7 +17,7 @@ Install Python 3.7, with full scientific stack. The Anaconda_ distribution is re
 * pandas>= 0.19
 * xlrd >= 0.9
 * pickle
-* pyyaml
+* pyyaml >= 5.1
 * pytest
 
 Using Dispa-SET:

--- a/dispaset/preprocessing/data_handler.py
+++ b/dispaset/preprocessing/data_handler.py
@@ -555,7 +555,7 @@ def load_config_yaml(filename, AbsPath=True):
     import yaml
     with open(filename, 'r') as f:
         try:
-            config = yaml.load(f)
+            config = yaml.full_load(f)
         except yaml.YAMLError as exc:
             logging.error('Cannot parse config file: {}'.format(filename))
             raise exc

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - xlrd >= 0.9
   - xarray >= 0.11
   - netcdf4
-  - pyyaml
+  - pyyaml >= 5.1
   - pytest
   - pip
   - pip:


### PR DESCRIPTION
PyYAML yaml.load(input) Deprecation

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation